### PR TITLE
Updated to new io and partially to new paths for compatibility with the ...

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, io, path, env, fs)]
+#![feature(core, io, path, fs)]
 
 //! # Handlebars for Iron
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, io, path, fs)]
+#![feature(core, io, path)]
 
 //! # Handlebars for Iron
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, io, path, env, old_path, fs)]
+#![feature(core, io, path, env, fs)]
 
 //! # Handlebars for Iron
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, old_io, old_path, env)]
+#![feature(core, io, path, env, old_path, fs)]
 
 //! # Handlebars for Iron
 //!

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
-use std::old_io::{File};
+use std::fs::{File};
+use std::io::Read;
 use std::env;
 
 use iron::prelude::*;
@@ -75,12 +76,14 @@ impl HandlebarsEngine {
         for entry in glob(pattern.as_slice()).unwrap() {
             match entry {
                 Ok(path) => {
-                    let disp = path.as_str().unwrap();
+                    let disp = path.to_str().unwrap();
+                    let mut template = String::new();
+                    File::open(&path).ok()
+                        .expect(format!("Failed to open file {}", disp).as_slice())
+                        .read_to_string(&mut template).unwrap();
                     let t = r.register_template_string(
                         &disp[prefix_path_str.len()+1 .. disp.len()-suffix.len()],
-                        File::open(&path).ok()
-                            .expect(format!("Failed to open file {}", disp).as_slice())
-                            .read_to_string().unwrap());
+                        template);
 
                     if t.is_err() {
                         panic!("Failed to create template.");

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use std::fs::{File};
 use std::io::Read;
+use std::path::Path;
 use std::env;
 
 use iron::prelude::*;
@@ -66,7 +67,7 @@ impl HandlebarsEngine {
             panic!("failed to get current working directory");
         }
         let abs_prefix_path = current_dir.ok().unwrap().join(prefix_path);
-        let prefix_path_str = abs_prefix_path.as_str().unwrap();
+        let prefix_path_str = abs_prefix_path.to_str().unwrap();
 
         let mut pattern = String::new();
         pattern.push_str(prefix_path_str);


### PR DESCRIPTION
Handlebars-iron now builds with the newest glob crate that returns Paths of the new type. env::current_dir() of the standard library still returns old_path types, so this is only a partial reform.
