### PR TITLE
Feature/notify, added support for template live-reload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ readme = "README.md"
 
 [dependencies]
 
-iron = "*"
+##iron = "*"
 handlebars = "*"
 rustc-serialize = "*"
 plugin = "*"
-#notify = "*"
+notify = "*"
 
 [dev-dependencies]
 tojson_macros = "*"
+
+[dependencies.iron]
+path = "../../var/src/iron"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 
-##iron = "*"
+iron = "*"
 handlebars = "*"
 rustc-serialize = "*"
 plugin = "*"
@@ -22,5 +22,3 @@ notify = "*"
 [dev-dependencies]
 tojson_macros = "*"
 
-[dependencies.iron]
-path = "../../var/src/iron"

--- a/examples/watch_server.rs
+++ b/examples/watch_server.rs
@@ -1,6 +1,3 @@
-#![feature(custom_derive, plugin)]
-#![plugin(tojson_macros)]
-
 extern crate iron;
 extern crate handlebars_iron as hbs;
 extern crate rustc_serialize;
@@ -12,10 +9,18 @@ use rustc_serialize::json::{ToJson, Json};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-#[derive(ToJson)]
 struct Team {
     name: String,
     pts: u16
+}
+
+impl ToJson for Team {
+    fn to_json(&self) -> Json {
+        let mut m: BTreeMap<String, Json> = BTreeMap::new();
+        m.insert("name".to_string(), self.name.to_json());
+        m.insert("pts".to_string(), self.pts.to_json());
+        m.to_json()
+    }
 }
 
 fn make_data () -> BTreeMap<String, Json> {

--- a/examples/watch_server.rs
+++ b/examples/watch_server.rs
@@ -1,0 +1,57 @@
+#![feature(custom_derive, plugin)]
+#![plugin(tojson_macros)]
+
+extern crate iron;
+extern crate handlebars_iron as hbs;
+extern crate rustc_serialize;
+
+use iron::prelude::*;
+use iron::{status};
+use hbs::{Template, HandlebarsEngine, Watchable};
+use rustc_serialize::json::{ToJson, Json};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+#[derive(ToJson)]
+struct Team {
+    name: String,
+    pts: u16
+}
+
+fn make_data () -> BTreeMap<String, Json> {
+    let mut data = BTreeMap::new();
+
+    data.insert("year".to_string(), "2015".to_json());
+
+    let teams = vec![ Team { name: "Jiangsu Sainty".to_string(),
+                             pts: 43u16 },
+                      Team { name: "Beijing Guoan".to_string(),
+                             pts: 27u16 },
+                      Team { name: "Guangzhou Evergrand".to_string(),
+                             pts: 22u16 },
+                      Team { name: "Shandong Luneng".to_string(),
+                             pts: 12u16 } ];
+
+    data.insert("teams".to_string(), teams.to_json());
+    data
+}
+
+/// the handler
+fn hello_world(_: &mut Request) -> IronResult<Response> {
+    let mut resp = Response::new();
+
+    let data = make_data();
+    resp.set_mut(Template::new("index", data)).set_mut(status::Ok);
+    Ok(resp)
+}
+
+fn main() {
+    let mut chain = Chain::new(hello_world);
+    let template_engine_ref = Arc::new(HandlebarsEngine::new("./examples/templates/", ".hbs"));
+    template_engine_ref.watch();
+
+    chain.link_after(template_engine_ref);
+
+    println!("Server running at http://localhost:3000/");
+    Iron::new(chain).http("localhost:3000").unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,11 @@ extern crate iron;
 extern crate rustc_serialize as serialize;
 extern crate handlebars;
 extern crate plugin;
+extern crate notify;
 
 pub use self::middleware::Template;
 pub use self::middleware::HandlebarsEngine;
+pub use self::watch::Watchable;
 
 mod middleware;
+mod watch;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::io::prelude::*;
 use std::result::Result;
 use std::env;
+use std::sync::RwLock;
 
 use iron::prelude::*;
 use iron::{AfterMiddleware, typemap};
@@ -13,10 +14,6 @@ use iron::headers::ContentType;
 
 use handlebars::Handlebars;
 use serialize::json::{ToJson, Json};
-
-pub struct HandlebarsEngine {
-    registry: Box<Handlebars>
-}
 
 #[derive(Clone)]
 pub struct Template {
@@ -31,6 +28,12 @@ impl Template {
             value: value.to_json()
         }
     }
+}
+
+pub struct HandlebarsEngine {
+    pub prefix: String,
+    pub suffix: String,
+    pub registry: RwLock<Box<Handlebars>>
 }
 
 impl typemap::Key for HandlebarsEngine {
@@ -55,11 +58,12 @@ impl PluginFor<Response> for HandlebarsEngine {
 }
 
 impl HandlebarsEngine {
-    pub fn new(prefix: &str, suffix: &str) -> HandlebarsEngine {
-        let mut r = Handlebars::new();
+    pub fn reload(&self) {
+        let mut prefix_slash = self.prefix.clone();
+        let suffix: &str = self.suffix.as_ref();
+        let mut hbs = self.registry.write().unwrap();
 
-        let mut prefix_slash = prefix.to_string();
-        let normalized_prefix = if prefix.ends_with("/") {
+        let normalized_prefix = if self.prefix.ends_with("/") {
             prefix_slash
         } else {
             prefix_slash.push('/');
@@ -79,6 +83,8 @@ impl HandlebarsEngine {
         if !walker.is_ok() {
             panic!("Failed to list directory.");
         }
+
+        hbs.clear_templates();
         for p in walker.ok().unwrap().filter_map(Result::ok) {
             let path = p.path();
             let disp = path.to_str().unwrap();
@@ -89,17 +95,23 @@ impl HandlebarsEngine {
                 file.read_to_string(&mut buf).ok()
                     .expect(format!("Failed to read file {}", disp).as_ref());
 
-                let t = r.register_template_string(
+                let t = hbs.register_template_string(
                     &disp[normalized_prefix.len() .. disp.len()-suffix.len()], buf);
                 if t.is_err() {
                     panic!("Failed to create template.");
                 }
             }
         }
+    }
 
-        HandlebarsEngine {
-            registry: Box::new(r)
-        }
+    pub fn new(prefix: &str, suffix: &str) -> HandlebarsEngine {
+        let eng = HandlebarsEngine {
+            prefix: prefix.to_string(),
+            suffix: suffix.to_string(),
+            registry: RwLock::new(Box::new(Handlebars::new()))
+        };
+        eng.reload();
+        eng
     }
 }
 
@@ -111,7 +123,8 @@ impl AfterMiddleware for HandlebarsEngine {
             Some(ref h) => {
                 let name = &h.name;
                 let value = &h.value;
-                let rendered = self.registry.render(name.as_ref(), value);
+                let hbs = self.registry.read().unwrap();
+                let rendered = hbs.render(name.as_ref(), value);
                 match rendered {
                     Ok(r) => Some(r),
                     Err(_) => None
@@ -139,6 +152,7 @@ mod test {
     use std::collections::BTreeMap;
     use iron::prelude::*;
     use middleware::*;
+    use handlebars::{Handlebars, RenderError, RenderContext, Helper, Context};
 
     fn hello_world() -> IronResult<Response> {
         let resp = Response::new();
@@ -164,5 +178,14 @@ mod test {
             },
             _ => panic!("template expected")
         }
+    }
+
+    #[test]
+    fn test_register_helper() {
+        let hbs = HandlebarsEngine::new("./examples/templates", ".hbs");
+        let mut reg = hbs.registry.write().unwrap();
+        reg.register_helper("ignore", Box::new(|_: &Context, _: &Helper, _: &Handlebars, _: &mut RenderContext| -> Result<String, RenderError> {
+            Ok("".to_string())
+        }));
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -89,16 +89,18 @@ impl HandlebarsEngine {
             let path = p.path();
             let disp = path.to_str().unwrap();
             if disp.ends_with(suffix) {
-                let mut file = File::open(&path).ok()
-                    .expect(format!("Failed to open file {}", disp).as_ref());
-                let mut buf = String::new();
-                file.read_to_string(&mut buf).ok()
-                    .expect(format!("Failed to read file {}", disp).as_ref());
-
-                let t = hbs.register_template_string(
-                    &disp[normalized_prefix.len() .. disp.len()-suffix.len()], buf);
-                if t.is_err() {
-                    panic!("Failed to create template.");
+                if let Ok(mut file) = File::open(&path) {
+                    let mut buf = String::new();
+                    if let Ok(_) = file.read_to_string(&mut buf) {
+                        if let Err(e) = hbs.register_template_string(
+                            &disp[normalized_prefix.len() .. disp.len()-suffix.len()], buf){
+                            println!("Failed to parse template {}", e);
+                        }
+                    } else {
+                        println!("Failed to read file {}, skipped", disp);
+                    }
+                } else {
+                    println!("Failed to open file {}, skipped.", disp);
                 }
             }
         }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,38 @@
+use middleware::HandlebarsEngine;
+
+use notify::{RecommendedWatcher, Error, Watcher};
+use std::path::Path;
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::thread;
+
+fn _watch (p: String) -> Result<(), Error>{
+    let (tx, rx) = channel();
+    let mut watcher: RecommendedWatcher = try!(Watcher::new(tx));
+    try!(watcher.watch(&Path::new(&p)));
+    let _ = rx.recv();
+    Ok(())
+}
+
+pub trait Watchable {
+    fn watch(&self);
+}
+
+impl Watchable for Arc<HandlebarsEngine> {
+    #[allow(while_true)]
+    fn watch (&self) {
+        let hbs = self.clone();
+        thread::spawn(move || {
+            println!("watching path: {}", hbs.prefix);
+            while true {
+                if let Ok(_) = _watch(hbs.prefix.clone()) {
+                    println!("things changed");
+                    hbs.reload();
+                } else {
+                    panic!("Failed to watch template directory.");
+                }
+            }
+        });
+
+    }
+}


### PR DESCRIPTION
Template directory can be watch by a `watch()` call. And each time you have templates added/changed/deleted, the engine automatically reload all templates without restarting server.
