### PR TITLE
(chore) make watch function an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,8 @@ handlebars = "*"
 rustc-serialize = "*"
 plugin = "*"
 walker = "*"
-notify = "*"
+notify = { version = "*", optional = true }
+
+[features]
+default = []
+watch = ["notify"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ During development you may want to live-reload your templates without
 having to restart your web server. Here comes the live-reload
 feature.
 
+Since live-reload may only be useful in development phase, we have
+made it a optional feature. In order to enable it, you will need to
+add feature `watch` in your cargo declaration:
+
+```
+[features]
+## create a feature in your app
+watch = ["handlebars-iron/watch"]
+
+[dependencies]
+handlebars-iron = "*"
+```
+
 ```rust
     let template_engine_ref = Arc::new(HandlebarsEngine::new("./examples/templates/", ".hbs"));
     template_engine_ref.watch();
@@ -65,7 +78,8 @@ feature.
     chain.link_after(template_engine_ref);
 ```
 
-Check `examples/watch_server.rs` for further information.
+Check `examples/watch_server.rs` for further information. To test it:
+`cargo run --example watch_server --features watch`.
 
 ## License
 

--- a/examples/watch_server.rs
+++ b/examples/watch_server.rs
@@ -1,10 +1,13 @@
+#![allow(dead_code, unused_imports)]
 extern crate iron;
 extern crate handlebars_iron as hbs;
 extern crate rustc_serialize;
 
 use iron::prelude::*;
 use iron::{status};
-use hbs::{Template, HandlebarsEngine, Watchable};
+use hbs::{Template, HandlebarsEngine};
+#[cfg(feature = "watch")]
+use hbs::Watchable;
 use rustc_serialize::json::{ToJson, Json};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -50,6 +53,7 @@ fn hello_world(_: &mut Request) -> IronResult<Response> {
     Ok(resp)
 }
 
+#[cfg(feature = "watch")]
 fn main() {
     let mut chain = Chain::new(hello_world);
     let template_engine_ref = Arc::new(HandlebarsEngine::new("./examples/templates/", ".hbs"));
@@ -59,4 +63,9 @@ fn main() {
 
     println!("Server running at http://localhost:3000/");
     Iron::new(chain).http("localhost:3000").unwrap();
+}
+
+#[cfg(not(feature = "watch"))]
+fn main() {
+    println!("Watch only enabled via --features watch option");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,16 @@ extern crate iron;
 extern crate rustc_serialize as serialize;
 extern crate handlebars;
 extern crate plugin;
-extern crate notify;
 extern crate walker;
+#[cfg(feature = "watch")]
+extern crate notify;
+
 
 pub use self::middleware::Template;
 pub use self::middleware::HandlebarsEngine;
+#[cfg(feature = "watch")]
 pub use self::watch::Watchable;
 
 mod middleware;
+#[cfg(feature = "watch")]
 mod watch;


### PR DESCRIPTION
Made watch/notify a optional feature so you won't have to deploy it into production.
