### PR TITLE
Do not use the default features of Iron

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 
-iron = "^0.2.0"
+iron = { version = "^0.2.0", default-features = false }
 handlebars = "^0.11.1"
 rustc-serialize = "^0.3.15"
 plugin = "^0.2.6"


### PR DESCRIPTION
By default, Iron includes openssl.
It is preferable to opt-out since this is not necessary for handlebars.
