### PR TITLE
Remove support for 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: rust
 rust:
   - nightly
-  - 1.4.0
-  - 1.3.0
   - beta
+  - stable
 branches:
   only:
     - master


### PR DESCRIPTION
hyper doesn't support it anymore since they want to have timeouts for
keep-alive connections, so we have no choice.
