### PR TITLE
make template names use forward slashes even on windows

### DIFF
--- a/src/sources/directory.rs
+++ b/src/sources/directory.rs
@@ -39,9 +39,10 @@ impl Source for DirectorySource {
             let tpl_path = p.path();
             let tpl_file_path = p.path().to_string_lossy();
             let tpl_name = &tpl_file_path[prefix_len .. tpl_file_path.len() - suffix_len];
+            let tpl_canonical_name = tpl_name.replace("\\", "/");
             debug!("getting file {}", tpl_file_path);
             debug!("register template {}", tpl_name);
-            try!(reg.register_template_file(&tpl_name, &tpl_path))
+            try!(reg.register_template_file(&tpl_canonical_name, &tpl_path))
         }
         Ok(())
     }


### PR DESCRIPTION
this should help users of handlebars-iron write code that works on both win and unix.
file paths are as before.
template names now universally use unix style path notation so the file "./template/controller/index.html.hbs" is now named "controller/index.html" on both platforms, instead of r#"controller\index.html"# on windows.
