### PR TITLE
implement `Send` for `SourceError`

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 #[derive(Debug)]
 pub struct SourceError {
-    pub cause: Box<Error>
+    pub cause: Box<Error + Send>,
 }
 
 impl fmt::Display for SourceError {


### PR DESCRIPTION
This allows it to be used with error-chain.