### PR TITLE
OSString for Directory source

### DIFF
--- a/src/sources/directory.rs
+++ b/src/sources/directory.rs
@@ -1,31 +1,31 @@
-use ::source::{Source, SourceError};
+use std::path::PathBuf;
+use std::ffi::{OsString, OsStr};
+
+use source::{Source, SourceError};
 
 use handlebars::Handlebars;
 use walkdir::{WalkDir, DirEntry};
 
 pub struct DirectorySource {
-    pub prefix: String,
-    pub suffix: String
+    pub prefix: OsString,
+    pub suffix: OsString,
 }
 
 impl DirectorySource {
-    pub fn new(prefix: &str, suffix: &str) -> DirectorySource {
-        let mut prefix_owned = prefix.to_owned();
-        // append tailing slash
-        if ! prefix_owned.ends_with("/") {
-            prefix_owned.push_str("/");
-        }
+    pub fn new<P>(prefix: P, suffix: P) -> DirectorySource
+        where P: Into<PathBuf>
+    {
         DirectorySource {
-            prefix: prefix_owned,
-            suffix: suffix.to_owned()
+            prefix: prefix.into().into_os_string(),
+            suffix: suffix.into().into_os_string(),
         }
     }
 }
 
-fn filter_file(entry: &DirEntry, suffix: &str) -> bool {
-    entry.file_name().to_str()
-        .map(|s| s.starts_with(".") || s.starts_with("#") || !s.ends_with(suffix))
-        .unwrap_or(false)
+fn filter_file(entry: &DirEntry, suffix: &OsStr) -> bool {
+    let path = entry.path();
+
+    path.starts_with(".") || path.starts_with("#") || !path.ends_with(suffix)
 }
 
 impl Source for DirectorySource {
@@ -33,15 +33,19 @@ impl Source for DirectorySource {
         let suffix_len = self.suffix.len();
         let prefix_len = self.prefix.len();
 
-        info!("Loading templates from path {}", self.prefix);
+        info!("Loading templates from path {:?}", self.prefix);
         let walker = WalkDir::new(&self.prefix);
-        for p in walker.min_depth(1).into_iter().filter(|e| e.is_ok() && !filter_file(e.as_ref().unwrap(), &self.suffix)).map(|e| e.unwrap()) {
+        for p in walker
+                .min_depth(1)
+                .into_iter()
+                .filter(|e| e.is_ok() && !filter_file(e.as_ref().unwrap(), &self.suffix))
+                .map(|e| e.unwrap()) {
             let tpl_path = p.path();
             let tpl_file_path = p.path().to_string_lossy();
-            let tpl_name = &tpl_file_path[prefix_len .. tpl_file_path.len() - suffix_len];
+            let tpl_name = &tpl_file_path[prefix_len..tpl_file_path.len() - suffix_len];
             let tpl_canonical_name = tpl_name.replace("\\", "/");
-            debug!("getting file {}", tpl_file_path);
-            debug!("register template {}", tpl_name);
+            debug!("getting file {:?}", tpl_file_path);
+            debug!("register template {:?}", tpl_name);
             try!(reg.register_template_file(&tpl_canonical_name, &tpl_path))
         }
         Ok(())

--- a/src/sources/directory.rs
+++ b/src/sources/directory.rs
@@ -34,7 +34,7 @@ fn filter_file(entry: &DirEntry, suffix: &OsStr) -> bool {
                  ds.starts_with(".") || ds.starts_with("#") ||
                  !ds.ends_with(suffix.to_string_lossy().as_ref())
              })
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 impl Source for DirectorySource {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -22,7 +22,7 @@ fn test_template() {
 }
 
 #[test]
-fn test_template2() {
+fn test_template_without_slash() {
     let mut hbse = HandlebarsEngine::new();
     let src = Box::new(DirectorySource::new("./examples/templates", ".hbs"));
 


### PR DESCRIPTION
Fixes #62 

Use `std::ffi::OsString` for directory path type.